### PR TITLE
fix(gui): use software keyboard for ImGui text fields

### DIFF
--- a/soh/soh/Enhancements/audio/AudioEditor.cpp
+++ b/soh/soh/Enhancements/audio/AudioEditor.cpp
@@ -675,6 +675,9 @@ void AudioEditor::DrawElement() {
             static ImGuiTextFilter sequenceSearch;
             UIWidgets::PushStyleInput(THEME_COLOR);
             sequenceSearch.Draw("Filter (inc,-exc)", 490.0f);
+#if defined(__SWITCH__)
+            ApplySwitchKeyboard(sequenceSearch);
+#endif
             UIWidgets::PopStyleInput();
             ImGui::SameLine();
             if (UIWidgets::Button("Exclude All",

--- a/soh/soh/Enhancements/debugger/MessageViewer.cpp
+++ b/soh/soh/Enhancements/debugger/MessageViewer.cpp
@@ -39,17 +39,26 @@ void MessageViewer::DrawElement() {
     PushStyleInput(THEME_COLOR);
     ImGui::InputText("##TableID", mTableIdBuf, MAX_STRING_SIZE, ImGuiInputTextFlags_CallbackCharFilter,
                      UIWidgets::TextFilters::FilterAlphaNum);
+#if defined(__SWITCH__)
+    ApplySwitchKeyboard(mTableIdBuf, MAX_STRING_SIZE);
+#endif
     UIWidgets::InsertHelpHoverText("Leave blank for vanilla table");
     ImGui::Text("Text ID");
     ImGui::SameLine();
     switch (mTextIdBase) {
         case DECIMAL:
             ImGui::InputText("##TextID", mTextIdBuf, MAX_STRING_SIZE, ImGuiInputTextFlags_CharsDecimal);
+#if defined(__SWITCH__)
+            ApplySwitchKeyboard(mTextIdBuf, MAX_STRING_SIZE);
+#endif
             UIWidgets::InsertHelpHoverText("Decimal Text ID of the message to load. Decimal digits only (0-9).");
             break;
         case HEXADECIMAL:
         default:
             ImGui::InputText("##TextID", mTextIdBuf, MAX_STRING_SIZE, ImGuiInputTextFlags_CharsHexadecimal);
+#if defined(__SWITCH__)
+            ApplySwitchKeyboard(mTextIdBuf, MAX_STRING_SIZE);
+#endif
             UIWidgets::InsertHelpHoverText(
                 "Hexadecimal Text ID of the message to load. Hexadecimal digits only (0-9/A-F).");
             break;
@@ -80,6 +89,9 @@ void MessageViewer::DrawElement() {
                                    "from the output.");
     PushStyleInput(THEME_COLOR);
     ImGui::InputTextMultiline("##CustomMessage", mCustomMessageBuf, MAX_STRING_SIZE);
+#if defined(__SWITCH__)
+    ApplySwitchKeyboard(mCustomMessageBuf, MAX_STRING_SIZE);
+#endif
     PopStyleInput();
     if (ImGui::Button("Display Message##CustomMessage")) {
         mDisplayCustomMessageClicked = true;

--- a/soh/soh/Enhancements/debugger/debugSaveEditor.cpp
+++ b/soh/soh/Enhancements/debugger/debugSaveEditor.cpp
@@ -1132,6 +1132,9 @@ void DrawFlagsTab() {
             ImGui::SetNextItemWidth(ImGui::GetFontSize() * 16);
             PushStyleInput(THEME_COLOR);
             flagFilter.Draw();
+#if defined(__SWITCH__)
+            ApplySwitchKeyboard(flagFilter);
+#endif
             PopStyleInput();
             ImGui::Spacing();
 

--- a/soh/soh/Enhancements/debugger/dlViewer.cpp
+++ b/soh/soh/Enhancements/debugger/dlViewer.cpp
@@ -99,6 +99,14 @@ void DLViewerWindow::DrawElement() {
         doSearch = true;
         searchDebounceFrames = 30;
     }
+
+#if defined(__SWITCH__)
+    if (UIWidgets::ApplySwitchKeyboard(searchString, ARRAY_COUNT(searchString))) {
+        doSearch = true;
+        searchDebounceFrames = 30;
+    }
+#endif
+
     UIWidgets::PopStyleInput();
 
     if (doSearch) {

--- a/soh/soh/Enhancements/debugger/valueViewer.cpp
+++ b/soh/soh/Enhancements/debugger/valueViewer.cpp
@@ -302,6 +302,14 @@ void ValueViewerWindow::DrawElement() {
                     setting.prefix = prefix;
                     SaveValueConfig();
                 }
+
+#if defined(__SWITCH__)
+                if (UIWidgets::ApplySwitchKeyboard(prefix, 10)) {
+                    setting.prefix = prefix;
+                    SaveValueConfig();
+                }
+#endif
+
                 UIWidgets::PopStyleInput();
                 ImGui::SameLine();
                 if (ImGui::ColorEdit3(("##color" + std::string(element.name)).c_str(), (float*)&setting.color,

--- a/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
@@ -1121,6 +1121,13 @@ void CheckTrackerWindow::DrawElement() {
             if (checkSearch.Draw("", ImGui::GetContentRegionAvail().x - 42)) {
                 UpdateFilters();
             }
+
+#if defined(__SWITCH__)
+            if (ApplySwitchKeyboard(checkSearch)) {
+                UpdateFilters();
+            }
+#endif
+
             std::string checkSearchText = checkSearch.InputBuf;
             checkSearchText.erase(std::remove(checkSearchText.begin(), checkSearchText.end(), ' '),
                                   checkSearchText.end());

--- a/soh/soh/Enhancements/randomizer/randomizer_entrance_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_entrance_tracker.cpp
@@ -876,6 +876,13 @@ void EntranceTrackerWindow::DrawElement() {
         if (locationSearch.Draw()) {
             nextTreeState = 2;
         }
+
+#if defined(__SWITCH__)
+        if (ApplySwitchKeyboard(locationSearch)) {
+            nextTreeState = 2;
+        }
+#endif
+
         PopStyleCombobox();
 
         uint8_t destToggle = CVarGetInteger(CVAR_TRACKER_ENTRANCE("SortBy"), 0);

--- a/soh/soh/Enhancements/randomizer/randomizer_item_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_item_tracker.cpp
@@ -1409,6 +1409,14 @@ void DrawNotes(bool resizeable = false) {
             notesNeedSave = true;
             notesIdleFrames = 0;
         }
+
+#if defined(__SWITCH__)
+        if (ApplySwitchKeyboard(itemTrackerNotes)) {
+            notesNeedSave = true;
+            notesIdleFrames = 0;
+        }
+#endif
+
         if ((ImGui::IsItemDeactivatedAfterEdit() || (notesNeedSave && notesIdleFrames > notesMaxIdleFrames)) &&
             IsValidSaveFile()) {
             notesNeedSave = false;

--- a/soh/soh/Enhancements/timesplits/TimeSplits.cpp
+++ b/soh/soh/Enhancements/timesplits/TimeSplits.cpp
@@ -824,6 +824,9 @@ void TimeSplitsDrawOptionsMenu() {
     ImGui::PushItemWidth(150.0f);
     PushStyleInput(THEME_COLOR);
     ImGui::InputText("##listName", listNameBuf, 25);
+#if defined(__SWITCH__)
+    ApplySwitchKeyboard(listNameBuf, 25);
+#endif
     PopStyleInput();
     ImGui::PopItemWidth();
     ImGui::SameLine();

--- a/soh/soh/SohGui/Menu.cpp
+++ b/soh/soh/SohGui/Menu.cpp
@@ -546,6 +546,7 @@ void Menu::MenuDrawItem(WidgetInfo& widget, uint32_t width, UIWidgets::Colors me
                 UIWidgets::PushStyleCombobox(menuThemeIndex);
                 ImGui::PushStyleColor(ImGuiCol_Border, UIWidgets::ColorValues.at(menuThemeIndex));
                 menuSearch.Draw();
+
 #ifdef __SWITCH__
                 const auto searchId = ImGui::GetItemID();
 
@@ -562,6 +563,7 @@ void Menu::MenuDrawItem(WidgetInfo& widget, uint32_t width, UIWidgets::Colors me
                     menuSearch.Build();
                 }
 #endif
+
                 ImGui::PopStyleColor();
                 UIWidgets::PopStyleCombobox();
                 UIWidgets::PopStyleButton();
@@ -774,6 +776,7 @@ void Menu::DrawElement() {
         ImGui::PushStyleColor(ImGuiCol_FrameBg, color);
         ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 3.0f);
         menuSearch.Draw("##search", 200.0f);
+
 #ifdef __SWITCH__
         const auto searchId = ImGui::GetItemID();
 
@@ -789,6 +792,7 @@ void Menu::DrawElement() {
             menuSearch.Build();
         }
 #endif
+
         menuSearchText = menuSearch.InputBuf;
         menuSearchText.erase(std::remove(menuSearchText.begin(), menuSearchText.end(), ' '), menuSearchText.end());
         if (menuSearchText.length() < 1) {

--- a/soh/soh/SohGui/Menu.cpp
+++ b/soh/soh/SohGui/Menu.cpp
@@ -558,7 +558,7 @@ void Menu::MenuDrawItem(WidgetInfo& widget, uint32_t width, UIWidgets::Colors me
 
                 // Apply the inline keyboard's text (live keystrokes, enter, or cancel-revert) only when it actually
                 // changed.
-                if (std::string text; Switch::ConsumeKeyboardText(searchId, text)) {
+                if (std::string text; Switch::ConsumeKeyboardText(searchId, text, nullptr)) {
                     std::snprintf(menuSearch.InputBuf, IM_ARRAYSIZE(menuSearch.InputBuf), "%s", text.c_str());
                     menuSearch.Build();
                 }
@@ -787,7 +787,7 @@ void Menu::DrawElement() {
         }
 
         // Apply the inline keyboard's text (live keystrokes, enter, or cancel-revert) only when it actually changed.
-        if (std::string text; Switch::ConsumeKeyboardText(searchId, text)) {
+        if (std::string text; Switch::ConsumeKeyboardText(searchId, text, nullptr)) {
             std::snprintf(menuSearch.InputBuf, IM_ARRAYSIZE(menuSearch.InputBuf), "%s", text.c_str());
             menuSearch.Build();
         }

--- a/soh/soh/SohGui/Menu.cpp
+++ b/soh/soh/SohGui/Menu.cpp
@@ -8,6 +8,11 @@
 #include <spdlog/fmt/fmt.h>
 #include <tuple>
 
+#ifdef __SWITCH__
+#include <ship/port/switch/SwitchImpl.h>
+#include <imgui_internal.h>
+#endif
+
 extern "C" {
 #include "z64.h"
 extern PlayState* gPlayState;
@@ -541,6 +546,16 @@ void Menu::MenuDrawItem(WidgetInfo& widget, uint32_t width, UIWidgets::Colors me
                 UIWidgets::PushStyleCombobox(menuThemeIndex);
                 ImGui::PushStyleColor(ImGuiCol_Border, UIWidgets::ColorValues.at(menuThemeIndex));
                 menuSearch.Draw();
+#ifdef __SWITCH__
+                if (ImGui::IsItemActivated() || ImGui::GetCurrentContext()->NavActivateId == ImGui::GetItemID()) {
+                    Switch::ShowKeyboard(menuSearch.InputBuf);
+                }
+
+                if (std::string text; Switch::ConsumeKeyboardText(text)) {
+                    std::snprintf(menuSearch.InputBuf, IM_ARRAYSIZE(menuSearch.InputBuf), "%s", text.c_str());
+                    menuSearch.Build();
+                }
+#endif
                 ImGui::PopStyleColor();
                 UIWidgets::PopStyleCombobox();
                 UIWidgets::PopStyleButton();
@@ -753,6 +768,16 @@ void Menu::DrawElement() {
         ImGui::PushStyleColor(ImGuiCol_FrameBg, color);
         ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 3.0f);
         menuSearch.Draw("##search", 200.0f);
+#ifdef __SWITCH__
+        if (ImGui::IsItemActivated() || ImGui::GetCurrentContext()->NavActivateId == ImGui::GetItemID()) {
+            Switch::ShowKeyboard(menuSearch.InputBuf);
+        }
+
+        if (std::string text; Switch::ConsumeKeyboardText(text)) {
+            std::snprintf(menuSearch.InputBuf, IM_ARRAYSIZE(menuSearch.InputBuf), "%s", text.c_str());
+            menuSearch.Build();
+        }
+#endif
         menuSearchText = menuSearch.InputBuf;
         menuSearchText.erase(std::remove(menuSearchText.begin(), menuSearchText.end(), ' '), menuSearchText.end());
         if (menuSearchText.length() < 1) {

--- a/soh/soh/SohGui/Menu.cpp
+++ b/soh/soh/SohGui/Menu.cpp
@@ -547,11 +547,17 @@ void Menu::MenuDrawItem(WidgetInfo& widget, uint32_t width, UIWidgets::Colors me
                 ImGui::PushStyleColor(ImGuiCol_Border, UIWidgets::ColorValues.at(menuThemeIndex));
                 menuSearch.Draw();
 #ifdef __SWITCH__
-                if (ImGui::IsItemActivated() || ImGui::GetCurrentContext()->NavActivateId == ImGui::GetItemID()) {
-                    Switch::ShowKeyboard(menuSearch.InputBuf);
+                const auto searchId = ImGui::GetItemID();
+
+                // Open the inline software keyboard when the player activates the search box (NavActivateId catches a
+                // controller press, which never enters edit mode; IsItemActivated catches a mouse/touch click).
+                if (ImGui::IsItemActivated() || ImGui::GetCurrentContext()->NavActivateId == searchId) {
+                    Switch::ShowKeyboard(searchId, menuSearch.InputBuf);
                 }
 
-                if (std::string text; Switch::ConsumeKeyboardText(text)) {
+                // Apply the inline keyboard's text (live keystrokes, enter, or cancel-revert) only when it actually
+                // changed.
+                if (std::string text; Switch::ConsumeKeyboardText(searchId, text)) {
                     std::snprintf(menuSearch.InputBuf, IM_ARRAYSIZE(menuSearch.InputBuf), "%s", text.c_str());
                     menuSearch.Build();
                 }
@@ -769,11 +775,16 @@ void Menu::DrawElement() {
         ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 3.0f);
         menuSearch.Draw("##search", 200.0f);
 #ifdef __SWITCH__
-        if (ImGui::IsItemActivated() || ImGui::GetCurrentContext()->NavActivateId == ImGui::GetItemID()) {
-            Switch::ShowKeyboard(menuSearch.InputBuf);
+        const auto searchId = ImGui::GetItemID();
+
+        // Open the inline software keyboard when the player activates the search box (NavActivateId catches a
+        // controller press, which never enters edit mode; IsItemActivated catches a mouse/touch click).
+        if (ImGui::IsItemActivated() || ImGui::GetCurrentContext()->NavActivateId == searchId) {
+            Switch::ShowKeyboard(searchId, menuSearch.InputBuf);
         }
 
-        if (std::string text; Switch::ConsumeKeyboardText(text)) {
+        // Apply the inline keyboard's text (live keystrokes, enter, or cancel-revert) only when it actually changed.
+        if (std::string text; Switch::ConsumeKeyboardText(searchId, text)) {
             std::snprintf(menuSearch.InputBuf, IM_ARRAYSIZE(menuSearch.InputBuf), "%s", text.c_str());
             menuSearch.Build();
         }

--- a/soh/soh/SohGui/SohMenuRandomizer.cpp
+++ b/soh/soh/SohGui/SohMenuRandomizer.cpp
@@ -78,6 +78,9 @@ void DrawLocationsMenu(WidgetInfo& info) {
         static ImGuiTextFilter locationSearch;
         UIWidgets::PushStyleInput(THEME_COLOR);
         locationSearch.Draw();
+#if defined(__SWITCH__)
+        ApplySwitchKeyboard(locationSearch);
+#endif
         UIWidgets::PopStyleInput();
 
         ImGui::BeginChild("ChildIncludedLocations", ImVec2(0, -8));
@@ -318,6 +321,9 @@ void DrawTricksMenu(WidgetInfo& info) {
     static ImGuiTextFilter trickSearch;
     UIWidgets::PushStyleInput(THEME_COLOR);
     trickSearch.Draw("Filter (inc,-exc)", 490.0f);
+#if defined(__SWITCH__)
+    ApplySwitchKeyboard(trickSearch);
+#endif
     UIWidgets::PopStyleInput();
     if (CVarGetInteger(CVAR_RANDOMIZER_SETTING("LogicRules"), RO_LOGIC_GLITCHLESS) != RO_LOGIC_NO_LOGIC) {
         ImGui::SameLine();
@@ -555,6 +561,9 @@ void SohMenu::AddMenuRandomizer() {
             UIWidgets::PushStyleInput(THEME_COLOR);
             ImGui::InputText("##RandomizerSeed", seedString, MAX_SEED_STRING_SIZE,
                              ImGuiInputTextFlags_CallbackCharFilter, UIWidgets::TextFilters::FilterAlphaNum);
+#if defined(__SWITCH__)
+            ApplySwitchKeyboard(seedString, MAX_SEED_STRING_SIZE);
+#endif
             UIWidgets::Tooltip("Characters from a-z, A-Z, and 0-9 are supported.\n"
                                "Character limit is 1023, after which the seed will be truncated.");
             ImGui::SameLine();

--- a/soh/soh/SohGui/UIWidgets.cpp
+++ b/soh/soh/SohGui/UIWidgets.cpp
@@ -762,6 +762,32 @@ int InputTextResizeCallback(ImGuiInputTextCallbackData* data) {
     return 0;
 }
 
+#ifdef __SWITCH__
+bool ApplySwitchKeyboard(char* buffer, std::size_t bufferSize) {
+    const auto id = ImGui::GetItemID();
+    if (ImGui::IsItemActivated() || ImGui::GetCurrentContext()->NavActivateId == id) {
+        Ship::Switch::ShowKeyboard(id, buffer);
+    }
+
+    std::string out;
+    if (Ship::Switch::ConsumeKeyboardText(id, out)) {
+        std::snprintf(buffer, bufferSize, "%s", out.c_str());
+        return true;
+    }
+
+    return false;
+}
+
+bool ApplySwitchKeyboard(ImGuiTextFilter& filter) {
+    if (ApplySwitchKeyboard(filter.InputBuf, IM_ARRAYSIZE(filter.InputBuf))) {
+        filter.Build();
+        return true;
+    }
+
+    return false;
+}
+#endif
+
 bool InputString(const char* label, std::string* value, const InputOptions& options) {
     bool dirty = false;
     ImGui::PushID(label);

--- a/soh/soh/SohGui/UIWidgets.cpp
+++ b/soh/soh/SohGui/UIWidgets.cpp
@@ -795,6 +795,20 @@ bool InputString(const char* label, std::string* value, const InputOptions& opti
     if (ImGui::InputText(label, (char*)value->c_str(), value->capacity() + 1, flags, InputTextResizeCallback, value)) {
         dirty = true;
     }
+#ifdef __SWITCH__
+    const auto inputId = ImGui::GetItemID();
+
+    // Open the inline software keyboard when the field is activated and apply what the player types.  Scoped by the
+    // field's ID so concurrent text inputs don't capture each other's text.
+    if (ImGui::IsItemActivated() || ImGui::GetCurrentContext()->NavActivateId == inputId) {
+        Ship::Switch::ShowKeyboard(inputId, *value);
+    }
+
+    if (std::string text; Ship::Switch::ConsumeKeyboardText(inputId, text)) {
+        *value = text;
+        dirty = true;
+    }
+#endif
     if (value->empty() && !options.placeholder.empty()) {
         ImGui::SameLine(17.0f);
         ImGui::TextColored(ImVec4(1.0f, 1.0f, 1.0f, 0.4f), "%s", options.placeholder.c_str());

--- a/soh/soh/SohGui/UIWidgets.cpp
+++ b/soh/soh/SohGui/UIWidgets.cpp
@@ -775,12 +775,28 @@ bool ApplySwitchKeyboard(char* buffer, std::size_t bufferSize) {
         return true;
     }
 
-    return false;
+    return false; 
 }
 
 bool ApplySwitchKeyboard(ImGuiTextFilter& filter) {
     if (ApplySwitchKeyboard(filter.InputBuf, IM_ARRAYSIZE(filter.InputBuf))) {
         filter.Build();
+        return true;
+    }
+
+    return false;
+}
+
+bool ApplySwitchKeyboard(ImVector<char>& buffer) {
+    const auto id = ImGui::GetItemID();
+    if (ImGui::IsItemActivated() || ImGui::GetCurrentContext()->NavActivateId == id) {
+        Ship::Switch::ShowKeyboard(id, buffer.empty() ? "" : buffer.begin());
+    }
+
+    std::string out;
+    if (Ship::Switch::ConsumeKeyboardText(id, out)) {
+        buffer.resize(static_cast<int>(out.size()) + 1);
+        std::snprintf(buffer.begin(), buffer.size(), "%s", out.c_str());
         return true;
     }
 

--- a/soh/soh/SohGui/UIWidgets.hpp
+++ b/soh/soh/SohGui/UIWidgets.hpp
@@ -1069,6 +1069,10 @@ bool CVarSliderInt(const char* label, const char* cvarName, const IntSliderOptio
 bool SliderFloat(const char* label, float* value, const FloatSliderOptions& options = {});
 bool CVarSliderFloat(const char* label, const char* cvarName, const FloatSliderOptions& options = {});
 bool InputString(const char* label, std::string* value, const InputOptions& options = {});
+#if defined(__SWITCH__)
+bool ApplySwitchKeyboard(char* buffer, std::size_t bufferSize);
+bool ApplySwitchKeyboard(ImGuiTextFilter& filter);
+#endif
 bool CVarInputString(const char* label, const char* cvarName, const InputOptions& options = {});
 bool InputInt(const char* label, int32_t* value, const InputOptions& options = {});
 bool CVarInputInt(const char* label, const char* cvarName, const InputOptions& options = {});

--- a/soh/soh/SohGui/UIWidgets.hpp
+++ b/soh/soh/SohGui/UIWidgets.hpp
@@ -1070,8 +1070,12 @@ bool SliderFloat(const char* label, float* value, const FloatSliderOptions& opti
 bool CVarSliderFloat(const char* label, const char* cvarName, const FloatSliderOptions& options = {});
 bool InputString(const char* label, std::string* value, const InputOptions& options = {});
 #if defined(__SWITCH__)
+// Opens the inline software keyboard for the most recently drawn ImGui text item when it's activated, applying the
+// typed text.  Called immediately after the text widget.  Returns true when new text was written back.
 bool ApplySwitchKeyboard(char* buffer, std::size_t bufferSize);
 bool ApplySwitchKeyboard(ImGuiTextFilter& filter);
+// For dynamically-sized buffers (i.e., multiline notes); resizes the vector to fit.
+bool ApplySwitchKeyboard(ImVector<char>& buffer);
 #endif
 bool CVarInputString(const char* label, const char* cvarName, const InputOptions& options = {});
 bool InputInt(const char* label, int32_t* value, const InputOptions& options = {});


### PR DESCRIPTION
This depends on https://github.com/timschneeb/libultraship-switch/pull/2.

Implements the inline software keyboard so all ImGui text entry works.  This removes the need of an external keyboard for menu search, randomizer location/tricks/seed check + entrance trackers, item tracker notes, audio sequence search, debug tools, etc.

<!--- section:artifacts:start -->
### Build Artifacts
  - [debug-symbols-lto.zip](https://nightly.link/timschneeb/Shipwright-Switch/actions/artifacts/7762866115.zip)
  - [soh-nx-lto.zip](https://nightly.link/timschneeb/Shipwright-Switch/actions/artifacts/7762865758.zip)
  - [debug-symbols.zip](https://nightly.link/timschneeb/Shipwright-Switch/actions/artifacts/7762850447.zip)
  - [soh-nx.zip](https://nightly.link/timschneeb/Shipwright-Switch/actions/artifacts/7762850072.zip)
<!--- section:artifacts:end -->