### PR TITLE
feat(gfx): deko3d backend

### DIFF
--- a/soh/CMakeLists.txt
+++ b/soh/CMakeLists.txt
@@ -814,6 +814,36 @@ endif()
 
 if(CMAKE_SYSTEM_NAME MATCHES "NintendoSwitch")
 
+find_program(UAM_EXE uam HINTS ${DEVKITPRO}/tools/bin REQUIRED)
+set(DEKO3D_SHADER_SRC ${CMAKE_CURRENT_SOURCE_DIR}/../libultraship/src/fast/shaders/deko3d)
+set(DEKO3D_ROMFS ${CMAKE_CURRENT_BINARY_DIR}/romfs)
+set(DEKO3D_SHADER_OUT ${DEKO3D_ROMFS}/shaders/deko3d)
+file(MAKE_DIRECTORY ${DEKO3D_SHADER_OUT})
+
+set(DEKO3D_DKSH "")
+file(GLOB DEKO3D_VERT ${DEKO3D_SHADER_SRC}/*.vert.glsl)
+file(GLOB DEKO3D_FRAG ${DEKO3D_SHADER_SRC}/*.frag.glsl)
+foreach(SH ${DEKO3D_VERT} ${DEKO3D_FRAG})
+    get_filename_component(SH_NAME ${SH} NAME)
+    string(REPLACE ".glsl" ".dksh" OUT_NAME ${SH_NAME})
+    if (SH_NAME MATCHES "\\.vert\\.glsl$")
+        set(STAGE vert)
+    else()
+        set(STAGE frag)
+    endif()
+    add_custom_command(
+        OUTPUT ${DEKO3D_SHADER_OUT}/${OUT_NAME}
+        COMMAND ${UAM_EXE} -s ${STAGE} -o ${DEKO3D_SHADER_OUT}/${OUT_NAME} ${SH}
+        DEPENDS ${SH}
+        COMMENT "uam ${STAGE}: ${SH_NAME}"
+        VERBATIM
+    )
+    list(APPEND DEKO3D_DKSH ${DEKO3D_SHADER_OUT}/${OUT_NAME})
+endforeach()
+
+add_custom_target(deko3d_shaders DEPENDS ${DEKO3D_DKSH})
+add_dependencies(soh deko3d_shaders)
+
 nx_generate_nacp(Ship.nacp
    NAME "Ship of Harkinian"
    AUTHOR "${PROJECT_TEAM}"
@@ -823,6 +853,7 @@ nx_generate_nacp(Ship.nacp
 nx_create_nro(soh
     NACP Ship.nacp
     ICON ${CMAKE_CURRENT_SOURCE_DIR}/icon.jpg
+    ROMFS ${DEKO3D_ROMFS}
 )
 
 INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/soh.nro DESTINATION . COMPONENT ship)

--- a/soh/CMakeLists.txt
+++ b/soh/CMakeLists.txt
@@ -734,6 +734,7 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL "NintendoSwitch")
         "libultraship;"
 		"SDL2_net::SDL2_net-static"
         SDL2::SDL2
+        -ldeko3d
         -lglad
         Threads::Threads
         -lvorbisfile

--- a/soh/CMakeLists.txt
+++ b/soh/CMakeLists.txt
@@ -817,7 +817,7 @@ if(CMAKE_SYSTEM_NAME MATCHES "NintendoSwitch")
 find_program(UAM_EXE uam HINTS ${DEVKITPRO}/tools/bin REQUIRED)
 set(DEKO3D_SHADER_SRC ${CMAKE_CURRENT_SOURCE_DIR}/../libultraship/src/fast/shaders/deko3d)
 set(DEKO3D_ROMFS ${CMAKE_CURRENT_BINARY_DIR}/romfs)
-set(DEKO3D_SHADER_OUT ${DEKO3D_ROMFS}/shaders/deko3d)
+set(DEKO3D_SHADER_OUT ${DEKO3D_ROMFS}/shaders)
 file(MAKE_DIRECTORY ${DEKO3D_SHADER_OUT})
 
 set(DEKO3D_DKSH "")

--- a/soh/CMakeLists.txt
+++ b/soh/CMakeLists.txt
@@ -856,6 +856,12 @@ nx_create_nro(soh
     ROMFS ${DEKO3D_ROMFS}
 )
 
+add_custom_command(
+        OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/soh.nro
+        APPEND
+        DEPENDS ${DEKO3D_DKSH}
+)
+
 INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/soh.nro DESTINATION . COMPONENT ship)
 
 elseif(CMAKE_SYSTEM_NAME MATCHES "CafeOS")

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -276,6 +276,17 @@ static bool VerifyArchiveVersion(OTRVersion version);
 std::string portArchivePath = "";
 static bool sohArchiveVersionMatch = false;
 
+namespace {
+void BootTrace(const char* message) {
+    static const auto sPath = Ship::Context::GetPathRelativeToAppDirectory("logs/deko_trace.log");
+    if (const auto file = std::fopen(sPath.c_str(), "a")) {
+        std::fputs(message, file);
+        std::fputc('\n', file);
+        std::fclose(file);
+    }
+}
+} // namespace
+
 OTRGlobals::OTRGlobals() {
     context = Ship::Context::CreateUninitializedInstance("Ship of Harkinian", appShortName, "shipofharkinian.json");
 
@@ -309,8 +320,10 @@ OTRGlobals::OTRGlobals() {
     sohFast3dWindow =
         std::make_shared<Fast::Fast3dWindow>(std::vector<std::shared_ptr<Ship::GuiWindow>>({ sohInputEditorWindow }));
     context->InitWindow(sohFast3dWindow);
+    BootTrace("ctor: post-InitWindow");
 
     SohGui::SetupMenu();
+    BootTrace("ctor: post-SetupMenu");
 
     if (sohArchiveVersionMatch) {
 
@@ -330,9 +343,13 @@ OTRGlobals::OTRGlobals() {
         ImGui::GetIO().FontDefault = fontStandardLarger;
     }
 
+    BootTrace("ctor: post fonts");
+
     previousImGuiScaleIndex = -1;
     previousImGuiScale = defaultImGuiScale;
     ScaleImGui();
+
+    BootTrace("ctor: end");
 }
 
 typedef enum ExtractSteps {
@@ -397,6 +414,8 @@ extern std::shared_ptr<SohGui::SohMenu> mSohMenu;
 }
 
 void OTRGlobals::RunExtract(int argc, char* argv[]) {
+    BootTrace("RunExtract: enter");
+
     bool extractDone = false;
     ExtractSteps extractStep = ES_PORT_ARCHIVE;
     WindowsSteps windowsStep = WS_TEMP;
@@ -461,6 +480,8 @@ void OTRGlobals::RunExtract(int argc, char* argv[]) {
 #if not defined(__SWITCH__) && not defined(__WIIU__)
     CheckAndCreateModFolder();
 #endif
+
+    BootTrace("RunExtract: pre-loop");
 
     while (!extractDone) {
         if (SohGui::PopupsQueued() > 0 || extractionTask.has_value()) {
@@ -1528,12 +1549,16 @@ extern "C" void InitOTR(int argc, char* argv[]) {
     OTRGlobals::Instance = new OTRGlobals();
 #ifdef __SWITCH__
     Ship::Switch::Init(Ship::PreInitPhase);
+    BootTrace("InitOTR: post-Switch::Init");
 #elif defined(__WIIU__)
     Ship::WiiU::Init(appShortName);
 #endif
+    BootTrace("InitOTR: pre-RunExtract");
     OTRGlobals::Instance->RunExtract(argc, argv);
 
     OTRGlobals::Instance->Initialize();
+    BootTrace("InitOTR: post-Initialize");
+
     CustomMessageManager::Instance = new CustomMessageManager();
     ItemTableManager::Instance = new ItemTableManager();
     GameInteractor::Instance = new GameInteractor();
@@ -1550,6 +1575,7 @@ extern "C" void InitOTR(int argc, char* argv[]) {
 
     SohGui::SetupGuiElements();
     SohGui::SetupMenuElements();
+    BootTrace("InitOTR: post GUI setup");
 
     AudioCollection::Instance = new AudioCollection();
     ActorDB::Instance = new ActorDB();
@@ -1606,6 +1632,8 @@ extern "C" void InitOTR(int argc, char* argv[]) {
     ShipInit::InitAll();
     Rando::StaticData::InitHashMaps();
     OTRGlobals::Instance->gRandoContext->AddExcludedOptions();
+
+    BootTrace("InitOTR: end");
 }
 
 extern "C" void SaveManager_ThreadPoolWait() {
@@ -1794,7 +1822,18 @@ void RunCommands(Gfx* Commands, const std::vector<std::unordered_map<Mtx*, MtxF>
         static_cast<UIWidgets::Colors>(CVarGetInteger(CVAR_SETTING("Menu.Theme"), UIWidgets::Colors::LightBlue));
     ImGui::PushStyleColor(ImGuiCol_TitleBgActive, UIWidgets::ColorValues.at(themeColor));
     for (const auto& m : mtx_replacements) {
+        static bool sIsFirst = true;
+        if (sIsFirst) {
+            BootTrace("RunCommands: pre-DrawAndRunGraphicsCommands");
+        }
+
         wnd->DrawAndRunGraphicsCommands(Commands, m);
+
+        if (sIsFirst) {
+            BootTrace("RunCommands: post-DrawAndRunGraphicsCommands");
+            sIsFirst = false;
+        }
+
         intp->mInterpolationIndex++;
     }
     ImGui::PopStyleColor();

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -278,7 +278,7 @@ static bool sohArchiveVersionMatch = false;
 
 namespace {
 void BootTrace(const char* message) {
-    static const auto sPath = Ship::Context::GetPathRelativeToAppDirectory("logs/deko_trace.log");
+    static const auto sPath = Ship::Context::GetPathRelativeToAppDirectory("logs/deko3d_trace.log");
     if (const auto file = std::fopen(sPath.c_str(), "a")) {
         std::fputs(message, file);
         std::fputc('\n', file);


### PR DESCRIPTION
Second half of https://github.com/timschneeb/libultraship-switch/pull/3.

This half of the implementation ensures that the shaders are created and packed into romfs, and adds deko3d to the possible backend selections.  ImGui implementation is currently stubbed, but deko3d can still be turned on by changing the API in the config.

<!--- section:artifacts:start -->
### Build Artifacts
  - [debug-symbols.zip](https://nightly.link/timschneeb/Shipwright-Switch/actions/artifacts/7895909296.zip)
  - [soh-nx.zip](https://nightly.link/timschneeb/Shipwright-Switch/actions/artifacts/7895908781.zip)
  - [debug-symbols-lto.zip](https://nightly.link/timschneeb/Shipwright-Switch/actions/artifacts/7895886531.zip)
  - [soh-nx-lto.zip](https://nightly.link/timschneeb/Shipwright-Switch/actions/artifacts/7895885973.zip)
  - [soh-linux.zip](https://nightly.link/timschneeb/Shipwright-Switch/actions/artifacts/7895677605.zip)
<!--- section:artifacts:end -->